### PR TITLE
Feature/#101 주소검색페이지프래그먼트로변경

### DIFF
--- a/app/src/main/java/com/giftfunding/osds/base/BaseFragment.kt
+++ b/app/src/main/java/com/giftfunding/osds/base/BaseFragment.kt
@@ -33,6 +33,10 @@ abstract class BaseFragment<T : ViewBinding> : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        init()
+    }
+
+    private fun init() {
         navController = findNavController()
     }
 

--- a/app/src/main/java/com/giftfunding/osds/data/response/address/AddressSearchResultDocumentResponse.kt
+++ b/app/src/main/java/com/giftfunding/osds/data/response/address/AddressSearchResultDocumentResponse.kt
@@ -4,21 +4,37 @@ import com.google.gson.annotations.SerializedName
 import java.io.Serializable
 
 data class AddressSearchResultDocumentResponse(
+    @SerializedName("id")
+    var id: String?,
+    @SerializedName("place_name")
+    var placeName: String?,
+    @SerializedName("category_name")
+    var categoryName: String?,
+    @SerializedName("category_group_code")
+    var categoryGroupCode: String?,
+    @SerializedName("category_group_name")
+    var categoryGroupName: String?,
+    @SerializedName("phone")
+    var phone: String?,
     @SerializedName("address_name")
     var addressName: String?,
-
+    @SerializedName("road_address_name")
+    var roadAddressName: String?,
     @SerializedName("address_type")
     var addressType: String?,
-
     @SerializedName("x")
     var x: String?,
-
     @SerializedName("y")
     var y: String?,
+    @SerializedName("place_url")
+    var placeUrl: String?,
+    @SerializedName("distance")
+    var distance: String?,
+
+
 
     @SerializedName("address")
     var address: Address?,
-
     @SerializedName("road_address")
     var roadAddress: RoadAaddress?
 ) : Serializable

--- a/app/src/main/java/com/giftfunding/osds/data/response/address/AddressSearchResultMetaResponse.kt
+++ b/app/src/main/java/com/giftfunding/osds/data/response/address/AddressSearchResultMetaResponse.kt
@@ -8,5 +8,7 @@ data class AddressSearchResultMetaResponse(
     @SerializedName("pageable_count")
     var pageableCount: Int?,
     @SerializedName("is_end")
-    var isEnd: Boolean?
+    var isEnd: Boolean?,
+    @SerializedName("same_name")
+    var sameName: RegionInfo
 )

--- a/app/src/main/java/com/giftfunding/osds/data/response/address/AddressSearchResultResponseTemp.kt
+++ b/app/src/main/java/com/giftfunding/osds/data/response/address/AddressSearchResultResponseTemp.kt
@@ -1,9 +1,0 @@
-package com.giftfunding.osds.data.response.address
-
-import java.io.Serializable
-
-data class AddressSearchResultResponseTemp(
-    val searchKeyword: String,
-    val addressType: String,
-    val address: String
-) : Serializable

--- a/app/src/main/java/com/giftfunding/osds/data/response/address/RegionInfo.kt
+++ b/app/src/main/java/com/giftfunding/osds/data/response/address/RegionInfo.kt
@@ -1,0 +1,12 @@
+package com.giftfunding.osds.data.response.address
+
+import com.google.gson.annotations.SerializedName
+
+data class RegionInfo(
+    @SerializedName("region")
+    var region: List<String>,
+    @SerializedName("keyword")
+    var keyword: String?,
+    @SerializedName("selected_region")
+    var selectedRegion: String?
+)

--- a/app/src/main/java/com/giftfunding/osds/repository/AddressRepository.kt
+++ b/app/src/main/java/com/giftfunding/osds/repository/AddressRepository.kt
@@ -3,12 +3,10 @@ package com.giftfunding.osds.repository
 import com.giftfunding.osds.repository.remote.datasource.AddressDataSource
 
 class AddressRepository(private val addressDataSource: AddressDataSource) {
-    suspend fun getAddress(apiKey: String, keyword: String) =
-        addressDataSource.getKakaoAddressService().getAddress(apiKey, keyword)
 
-    //좌표값으로 주소지( 지번 또는 도로명) 가져오기
-    suspend fun getAddress(apiKey: String, x: String, y: String) =
-        addressDataSource.getKakaoAddressService().getAddress(apiKey, x, y)
+    //주소 검색
+    suspend fun getAddress(apiKey: String, keyword: String, page: Int) =
+        addressDataSource.getKakaoAddressService().getAddress(apiKey, keyword, page)
 
-    suspend fun addAddress(address : String) = addressDataSource.getAddress().postAddress(address)
+    suspend fun addAddress(address: String) = addressDataSource.getAddress().postAddress(address)
 }

--- a/app/src/main/java/com/giftfunding/osds/repository/remote/service/AddressService.kt
+++ b/app/src/main/java/com/giftfunding/osds/repository/remote/service/AddressService.kt
@@ -7,22 +7,16 @@ import retrofit2.http.*
 
 //레트로핏 인터페이스 선언
 interface AddressService {
+
     @GET("/v2/local/search/address.json")
     suspend fun getAddress(
         @Header("Authorization") token: String,
-        @Query("query") query: String
-    ): AddressSearchResultResponse
-
-    //좌표값으로 주소지( 지번 또는 도로명) 가져오기
-    @GET("/v2/local/geo/coord2address.json")
-    suspend fun getAddress(
-        @Header("Authorization") token: String,
-        @Query("x") x: String,
-        @Query("y") y: String,
+        @Query("query") query: String,
+        @Query("page") page: Int
     ): AddressSearchResultResponse
 
     @PATCH("api/user/me")
     suspend fun postAddress(
-        @Query("address") address:String
-    ):Response<User>
+        @Query("address") address: String
+    ): Response<User>
 }

--- a/app/src/main/java/com/giftfunding/osds/ui/address/AddressActivity.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/AddressActivity.kt
@@ -9,6 +9,8 @@ import com.giftfunding.osds.enum.BackButton
 import com.giftfunding.osds.enum.ToolbarType
 import com.giftfunding.osds.enum.VisibleState
 
+
+//삭제예정
 class AddressActivity : BaseActivity<ActivityAddressBinding>(ActivityAddressBinding::inflate) {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/giftfunding/osds/ui/address/AddressDetailActivity.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/AddressDetailActivity.kt
@@ -19,7 +19,7 @@ import com.giftfunding.osds.enum.BackButton
 import com.giftfunding.osds.enum.ToolbarType
 import com.giftfunding.osds.enum.VisibleState
 
-
+//삭제예정
 class AddressDetailActivity :
     BaseActivity<ActivityAddressDetailBinding>(ActivityAddressDetailBinding::inflate) {
 
@@ -53,10 +53,10 @@ class AddressDetailActivity :
     }
 
     private fun initAddressViewModel(){
-        viewModel.userResponse.observe(this){
-            finishAffinity()
+//        viewModel.userResponse.observe(this){
+//            finishAffinity()
 //            startActivity(Intent(this,HomeActivity::class.java))
-        }
+//        }
     }
 
     private fun initAddressTextViews(addressData: AddressSearchResultDocumentResponse) {
@@ -99,7 +99,7 @@ class AddressDetailActivity :
         binding.btnComplete.setOnClickListener {
             // TODO 회원가입 완료(주소 저장) API 호출
             val address = "${binding.tvAddress.text} ${binding.editAddressDetail.text}"
-            viewModel.addAddress(address)
+//            viewModel.addAddress(address)
         }
 
         binding.btnTextDelete.setOnClickListener {

--- a/app/src/main/java/com/giftfunding/osds/ui/address/AddressFragment.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/AddressFragment.kt
@@ -18,7 +18,7 @@ class AddressFragment : BaseFragment<FragmentAddressBinding>(){
 
     override fun initEvent() {
         binding.btnAddressSearch.setOnClickListener {
-//            startActivity(Intent(this, AddressSearchActivity::class.java))
+            navigate(AddressFragmentDirections.actionAddressFragmentToAddressSearchFragment())
         }
 
         //백 버튼 클릭시 어떤 화면으로 이동해야하나?

--- a/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchActivity.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchActivity.kt
@@ -18,18 +18,19 @@ import com.giftfunding.osds.data.response.address.AddressSearchResultResponse
 import com.giftfunding.osds.databinding.ActivityAddressSearchBinding
 import com.giftfunding.osds.enum.ToolbarType
 import com.giftfunding.osds.enum.VisibleState
-import com.giftfunding.osds.ui.address.adapter.AddressSearchAdapter
+import com.giftfunding.osds.ui.address.adapter.AddressSearchAdapter3
 import com.giftfunding.osds.ui.address.adapter.AddressSearchDetailAdapter
 
+//삭제 예정
 class AddressSearchActivity :
     BaseActivity<ActivityAddressSearchBinding>(ActivityAddressSearchBinding::inflate) {
 
     private val viewModel: AddressSearchViewModel by viewModels()
-    private val addressSearchAdapter = AddressSearchAdapter()
+    private val addressSearchAdapter3 = AddressSearchAdapter3()
     private val addressSearchDetailAdapter = AddressSearchDetailAdapter()
     private val itemClickListener = object : AddressSearchClickListener {
         override fun addressSearchClickable(addressName: AddressSearchResultDocumentResponse) {
-            getAddress(addressName)
+//            getAddress(addressName)
         }
     }
 
@@ -58,9 +59,9 @@ class AddressSearchActivity :
     }
 
     private fun initRecyclerView() {
-        addressSearchAdapter.setItemClickListener(itemClickListener)
+        addressSearchAdapter3.setItemClickListener(itemClickListener)
         binding.viewAddressSearchResult.rvAddressSearchResult.apply {
-            adapter = addressSearchAdapter
+            adapter = addressSearchAdapter3
             layoutManager =
                 LinearLayoutManager(this@AddressSearchActivity, LinearLayoutManager.VERTICAL, false)
         }
@@ -120,7 +121,7 @@ class AddressSearchActivity :
             ) {
                 updateEditAddressSearchBackground(address)
                 isShowAddressDeleteButton(address)
-                getAddress(address)
+//                getAddress(address)
             }
 
             override fun afterTextChanged(s: Editable?) {
@@ -169,20 +170,20 @@ class AddressSearchActivity :
     }
 
     // 주소 검색
-    private fun getAddress(address: CharSequence?) {
-        viewModel.getAddress(
-            "KakaoAK ${resources.getString(R.string.rest_api_key)}",
-            address.toString()
-        )
-    }
-
-    //좌표값으로 주소지( 지번 또는 도로명) 가져오기
-    private fun getAddress(addressData: AddressSearchResultDocumentResponse) {
-        viewModel.getAddress(
-            "KakaoAK ${resources.getString(R.string.rest_api_key)}",
-            addressData
-        )
-    }
+//    private fun getAddress(address: CharSequence?) {
+//        viewModel.getAddress(
+//            "KakaoAK ${resources.getString(R.string.rest_api_key)}",
+//            address.toString()
+//        )
+//    }
+//
+//    //좌표값으로 주소지( 지번 또는 도로명) 가져오기
+//    private fun getAddress(addressData: AddressSearchResultDocumentResponse) {
+//        viewModel.getAddress(
+//            "KakaoAK ${resources.getString(R.string.rest_api_key)}",
+//            addressData
+//        )
+//    }
 
     //응답 된 데이터 안에 주소 데이터의 존재 여부에 따라 뷰 업데이트
     private fun updateAddressSearchView(address: AddressSearchResultResponse) {
@@ -193,9 +194,9 @@ class AddressSearchActivity :
         }else{
             showAddressSearchResultView()
             // 검색 결과 보여주기 위해서 리사이클러 뷰 어뎁터에 데이터 넣어 줌
-            addressSearchAdapter.clearItems()
-            addressSearchAdapter.setKeyword(binding.editAddressSearch.text.toString())
-            address.documents?.let { addressSearchAdapter.addItems(it) }
+            addressSearchAdapter3.clearItems()
+            addressSearchAdapter3.setKeyword(binding.editAddressSearch.text.toString())
+            address.documents?.let { addressSearchAdapter3.addItems(it) }
         }
     }
 
@@ -226,14 +227,14 @@ class AddressSearchActivity :
 
     private fun initLiveData() {
         // 첫번째 주소 검색 결과
-        viewModel.isExistAddress.observe(this) { address ->
-            updateAddressSearchView(address)
-        }
+//        viewModel.isExistAddress.observe(this) { address ->
+//            updateAddressSearchView(address)
+//        }
 
         // 지번, 도로명 검색 결과
-        viewModel.isDetailAddress.observe(this){ address ->
-            updateAddressSearchDetailView(address)
-        }
+//        viewModel.isDetailAddress.observe(this){ address ->
+//            updateAddressSearchDetailView(address)
+//        }
     }
 
     /**

--- a/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchClickListener.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchClickListener.kt
@@ -2,6 +2,7 @@ package com.giftfunding.osds.ui.address
 
 import com.giftfunding.osds.data.response.address.AddressSearchResultDocumentResponse
 
+//삭제예정
 interface AddressSearchClickListener {
     fun addressSearchClickable(addressName: AddressSearchResultDocumentResponse)
 }

--- a/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchDetailClickListener.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchDetailClickListener.kt
@@ -2,6 +2,7 @@ package com.giftfunding.osds.ui.address
 
 import com.giftfunding.osds.data.response.address.AddressSearchResultDocumentResponse
 
+//삭제예정
 interface AddressSearchDetailClickListener {
     fun addressSearchDetailClickable(addressResult: AddressSearchResultDocumentResponse)
 }

--- a/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchFragment.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchFragment.kt
@@ -218,7 +218,7 @@ class AddressSearchFragment : BaseFragment<FragmentAddressSearchBinding>() {
 
     //스낵바로 에러 보여주기
     private fun showSnackBar(errorMessage: String) {
-        Util.showSnackBar(requireView(), errorMessage)
+        showSnackBar(requireView(), errorMessage)
     }
 
     companion object {

--- a/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchFragment.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchFragment.kt
@@ -1,0 +1,227 @@
+package com.giftfunding.osds.ui.address
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.KeyEvent
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.widget.TextView
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.giftfunding.osds.R
+import com.giftfunding.osds.base.BaseFragment
+import com.giftfunding.osds.data.response.address.AddressSearchResultResponse
+import com.giftfunding.osds.databinding.FragmentAddressSearchBinding
+import com.giftfunding.osds.ui.address.adapter.AddressSearchAdapter
+import com.giftfunding.osds.util.*
+
+class AddressSearchFragment : BaseFragment<FragmentAddressSearchBinding>() {
+
+    override fun layoutResId(): Int = R.layout.fragment_address_search
+
+    private val viewModel: AddressSearchViewModel by viewModels()
+    private val addressSearchAdapter = AddressSearchAdapter()
+    private var page = DEFAULT_PAGE
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        init()
+        initEvent()
+        initRecyclerView()
+        initObserverEvent()
+    }
+
+    private fun init() {
+        // 화면으로 들어올 때 자동으로 editText 포커스 및 키보드 올리기
+        binding.editAddressSearch.setFocusAndShowKeyboard(binding.editAddressSearch.context)
+    }
+
+    override fun initEvent() {
+        searchAddress()
+        editTextTextWatcher()
+        binding.btnTextDelete.setOnClickListener {
+            binding.editAddressSearch.text.clear()
+        }
+    }
+
+    private fun initRecyclerView() {
+        binding.viewAddressSearchResult.rvAddressSearchResult.apply {
+            adapter = addressSearchAdapter
+            layoutManager =
+                LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+        }
+    }
+
+    override fun initObserverEvent() {
+        //주소 검색 결과
+        viewModel.isExistAddress.observe(viewLifecycleOwner) { address ->
+            isExistAddressInformation(address)
+        }
+
+        // 주소 검색시 카카오 api 에서 주는 errorMessage ... 테스트 필요
+        viewModel.addressErrorMessage.observe(viewLifecycleOwner) { errorMessage ->
+            showSnackBar(errorMessage)
+        }
+
+        // editText에 텍스트가 입력되었을 떄, x 표시 보여주기
+        viewModel.isUserInputText.observe(viewLifecycleOwner) { isExistText ->
+            updateEditAddressSearchBackground(isExistText)
+        }
+    }
+
+    // editText에 주소를 입력 후 검색 버튼 클릭
+    private fun searchAddress() {
+        binding.editAddressSearch.setOnEditorActionListener(object :
+            TextView.OnEditorActionListener {
+            override fun onEditorAction(
+                textView: TextView?,
+                actionId: Int,
+                keyEvent: KeyEvent?
+            ): Boolean {
+                when (actionId) {
+                    EditorInfo.IME_ACTION_SEARCH -> {
+                        hideKeyboard()
+                        isSearchAddress(binding.editAddressSearch.text.toString())
+                    }
+                    else -> // 기본 엔터키 동작
+                        return false
+                }
+                return true
+            }
+        })
+    }
+
+    // editText에 주소지 검색했는지 확인하기
+    private fun isSearchAddress(address: String) {
+        if (address.isEmpty()) {
+            showSnackBar(getString(R.string.content_empty_address))
+            return
+        }
+
+        reSearchAddress()
+    }
+
+    // 재검색시 page 초기화, 주소 검색 내용 초기화
+    private fun reSearchAddress() {
+        initSearchConditions()
+        getAddress()
+    }
+
+    // 재검색을 위한 초기화
+    private fun initSearchConditions() {
+        page = DEFAULT_PAGE
+        addressSearchAdapter.clearItems()
+    }
+
+    //키워드로 주소 검색하기
+    private fun getAddress() {
+        viewModel.getAddress(
+            "KakaoAK ${resources.getString(R.string.rest_api_key)}",
+            binding.editAddressSearch.text.toString(),
+            page
+        )
+    }
+
+    // 검색 결과가 더 이상 없는지 확인하기
+    private fun isEndPage(address: AddressSearchResultResponse): Boolean? = address.meta!!.isEnd
+
+    //주소 검색 결과값이 있는지 없는지 판별
+    private fun isExistAddressInformation(address: AddressSearchResultResponse) {
+        if (address.documents.isNullOrEmpty()) {
+            showAddressSearchNoResultView()
+        } else {
+            showAddressSearchResultView()
+            addressSearchAdapter.addItems(address.documents!!)
+
+            //끝 페이지가 아니라면 , 페이지 증가하고 주소지 검색 더 하기
+            if (!isEndPage(address)!!) {
+                page++
+                getAddress()
+            }
+        }
+    }
+
+    // editText 텍스트 와쳐 리스너
+    private fun editTextTextWatcher() {
+        binding.editAddressSearch.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+            override fun afterTextChanged(text: Editable?) {
+                viewModel.afterTextChange(text.toString())
+            }
+        })
+    }
+
+    // edittext에 텍스트 존재 유무에 따라 뷰 갱신
+    private fun updateEditAddressSearchBackground(isExistText: Boolean) {
+        changeDeleteButtonVisibleState(isExistText)
+        changeBackgroundColor(isExistText)
+        changeDrawableStartVisibleState(isExistText)
+    }
+
+    // x 버튼 활성화 상태 변경
+    private fun changeDeleteButtonVisibleState(isExistText: Boolean) {
+        binding.btnTextDelete.visibility = if (isExistText) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
+    }
+
+    // edittext 백그라운드 색 변경
+    private fun changeBackgroundColor(isExistText: Boolean) {
+        if (isExistText) {
+            binding.editAddressSearch.changeBackgroundColor(
+                requireContext(),
+                R.drawable.bg_rect_midnight_express_white_radius16_stroke2
+            )
+        } else {
+            binding.editAddressSearch.changeBackgroundColor(
+                requireContext(),
+                R.drawable.bg_rect_midnight_express_solitude2_radius16_stroke2
+            )
+        }
+    }
+
+    // 검색 아이콘 표출 여부 변경
+    private fun changeDrawableStartVisibleState(isExistText: Boolean) {
+        if (isExistText) {
+            binding.editAddressSearch.hideSearchIcon()
+        } else {
+            binding.editAddressSearch.showSearchIcon(R.drawable.ic_search)
+        }
+    }
+
+    //검색 결과 없을 때 : 가이드, 결과 안보이게 하기
+    private fun showAddressSearchNoResultView() {
+        binding.viewAddressSearchGuide.root.visibility = View.GONE
+        binding.viewAddressSearchNoResult.root.visibility = View.VISIBLE
+        binding.viewAddressSearchResult.root.visibility = View.GONE
+    }
+
+    //검색 결과 존재 할 때 : 가이드, 결과 없음 안보이게 하기
+    private fun showAddressSearchResultView() {
+        binding.viewAddressSearchGuide.root.visibility = View.GONE
+        binding.viewAddressSearchNoResult.root.visibility = View.GONE
+        binding.viewAddressSearchResult.root.visibility = View.VISIBLE
+    }
+
+    //키보드 숨기기
+    private fun hideKeyboard() {
+        binding.editAddressSearch.clearFocusAndHideKeyboard(
+            binding.editAddressSearch.context
+        )
+    }
+
+    //스낵바로 에러 보여주기
+    private fun showSnackBar(errorMessage: String) {
+        Util.showSnackBar(requireView(), errorMessage)
+    }
+
+    companion object {
+        const val DEFAULT_PAGE = 1
+    }
+}

--- a/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchViewModel.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.giftfunding.osds.application.Application
-import com.giftfunding.osds.data.response.address.AddressSearchResultDocumentResponse
 import com.giftfunding.osds.data.response.address.AddressSearchResultResponse
 import com.giftfunding.osds.data.response.user.User
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -19,47 +18,28 @@ class AddressSearchViewModel : ViewModel() {
     val isExistAddress: LiveData<AddressSearchResultResponse>
         get() = _isExistAddress
 
-    private val _isExistDetailAddress = MutableLiveData<AddressSearchResultResponse>()
-    val isDetailAddress: LiveData<AddressSearchResultResponse>
-        get() = _isExistDetailAddress
+    private val _addressErrorMessage = MutableLiveData<String>()
+    val addressErrorMessage: LiveData<String>
+        get() = _addressErrorMessage
 
-    private val _userResponse = MutableLiveData<User>()
-    val userResponse: LiveData<User>
-        get() = _userResponse
+    private val _isUserInputText = MutableLiveData<Boolean>()
+    val isUserInputText : LiveData<Boolean>
+        get() = _isUserInputText
 
-    fun addAddress(address : String){
-        viewModelScope.launch(exceptionHandler){
-            val response = Application.addressRepository.addAddress(address)
-            if(response.isSuccessful){
-                _userResponse.value = response.body()
-            }
-            else {
-                Log.e("AddressSearchViewModel", "err")
-            }
+    // 주소 검색
+    fun getAddress(apiKey: String, keyword: String, page: Int) {
+        viewModelScope.launch(exceptionHandler) {
+            _isExistAddress.value = Application.addressRepository.getAddress(apiKey, keyword, page)
         }
     }
 
-    fun getAddress(apiKey: String, keyword: String) {
-        viewModelScope.launch(exceptionHandler) {
-            val result = Application.addressRepository.getAddress(apiKey, keyword)
-            _isExistAddress.value = result
-        }
-    }
-
-    //좌표값으로 주소지( 지번 또는 도로명) 가져오기
-    fun getAddress(apiKey: String, addressData: AddressSearchResultDocumentResponse) {
-        viewModelScope.launch(exceptionHandler) {
-            val result = Application.addressRepository.getAddress(
-                apiKey,
-                addressData.x.toString(),
-                addressData.y.toString()
-            )
-            _isExistDetailAddress.value = result
-        }
+    fun afterTextChange(text: String) {
+        _isUserInputText.value = text.isNotEmpty()
     }
 
     // 코루틴 예외처리
     private val exceptionHandler = CoroutineExceptionHandler { _, exception ->
+        _addressErrorMessage.value = exception.message.toString()
         Log.d(tag, exception.message.toString())
     }
 }

--- a/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchViewModel.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/AddressSearchViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.giftfunding.osds.application.Application
 import com.giftfunding.osds.data.response.address.AddressSearchResultResponse
-import com.giftfunding.osds.data.response.user.User
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
 
@@ -23,13 +22,14 @@ class AddressSearchViewModel : ViewModel() {
         get() = _addressErrorMessage
 
     private val _isUserInputText = MutableLiveData<Boolean>()
-    val isUserInputText : LiveData<Boolean>
+    val isUserInputText: LiveData<Boolean>
         get() = _isUserInputText
 
     // 주소 검색
     fun getAddress(apiKey: String, keyword: String, page: Int) {
         viewModelScope.launch(exceptionHandler) {
-            _isExistAddress.value = Application.addressRepository.getAddress(apiKey, keyword, page)
+            val result = Application.addressRepository.getAddress(apiKey, keyword, page)
+            _isExistAddress.value = result
         }
     }
 

--- a/app/src/main/java/com/giftfunding/osds/ui/address/adapter/AddressSearchAdapter.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/adapter/AddressSearchAdapter.kt
@@ -1,52 +1,37 @@
 package com.giftfunding.osds.ui.address.adapter
 
 import android.annotation.SuppressLint
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.giftfunding.osds.data.response.address.AddressSearchResultDocumentResponse
 import com.giftfunding.osds.databinding.ItemAddressSearchBinding
-import com.giftfunding.osds.ui.address.AddressSearchClickListener
-import com.giftfunding.osds.util.setAddressTextColor
 
 class AddressSearchAdapter :
-    RecyclerView.Adapter<AddressSearchAdapter.AddressSearchResultViewHolder>() {
+    RecyclerView.Adapter<AddressSearchAdapter.AddressSearchViewHolder>() {
 
-    private var addressItems = ArrayList<AddressSearchResultDocumentResponse>()
-    private lateinit var keyword: String
-    private lateinit var itemClickListener: AddressSearchClickListener
+    private val addressItems = mutableListOf<AddressSearchResultDocumentResponse>()
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
-    ): AddressSearchResultViewHolder =
-        AddressSearchResultViewHolder(
+    ): AddressSearchViewHolder =
+        AddressSearchViewHolder(
             ItemAddressSearchBinding.inflate(
                 LayoutInflater.from(parent.context), parent, false
             )
         )
 
-    override fun onBindViewHolder(holder: AddressSearchResultViewHolder, position: Int) {
-        holder.onBind(addressItems[position], keyword)
-        holder.itemView.setOnClickListener{
-            itemClickListener.addressSearchClickable(addressItems[position])
-        }
+    override fun onBindViewHolder(holder: AddressSearchViewHolder, position: Int) {
+        holder.onBind(addressItems[position])
     }
 
     override fun getItemCount(): Int = addressItems.size
 
-    // 인터페이스 주입
-    fun setItemClickListener(addressSearchClickListener: AddressSearchClickListener) {
-        this.itemClickListener = addressSearchClickListener
-    }
-
-    // 키워드 주입
-    fun setKeyword(keyword: String){
-        this.keyword = keyword
-    }
-
     @SuppressLint("NotifyDataSetChanged")
     fun addItems(address: List<AddressSearchResultDocumentResponse>) {
+        Log.d("addItems", " TEST ")
         addressItems.addAll(address)
         notifyDataSetChanged()
     }
@@ -57,17 +42,46 @@ class AddressSearchAdapter :
         notifyDataSetChanged()
     }
 
-    class AddressSearchResultViewHolder(
-        private val binding: ItemAddressSearchBinding,
-    ) :
+    class AddressSearchViewHolder(private val binding: ItemAddressSearchBinding) :
         RecyclerView.ViewHolder(binding.root) {
+        fun onBind(item: AddressSearchResultDocumentResponse) {
 
-        fun onBind(
-            item: AddressSearchResultDocumentResponse,
-            keyword: String,
-        ) {
-            binding.lAddressName.tvAddress.setAddressTextColor(item.addressName!!, keyword)
+            when (item.addressType) {
+                "REGION" -> {
+                    binding.lAddressResult.tvSearchKeyword.text = item.addressName
+                    binding.lAddressResult.tvAddress.text = item.address!!.addressName
+                    binding.lAddressResult.tvAddressType.text = "지번"
+                }
+
+                "REGION_ADDR" -> {
+                    binding.lAddressResult.tvSearchKeyword.text = item.addressName
+                    binding.lAddressResult.tvAddress.text = item.address!!.addressName
+                    binding.lAddressResult.tvAddressType.text = "지번"
+                }
+
+                "ROAD" -> {
+                    binding.lAddressResult.tvSearchKeyword.text = item.addressName
+                    binding.lAddressResult.tvAddress.text = item.roadAddress!!.addressName
+                    binding.lAddressResult.tvAddressType.text = "도로명"
+                }
+
+                "ROAD_ADDR" -> {
+                    isExistBuildingName(item)
+                    binding.lAddressResult.tvAddress.text = item.roadAddress!!.addressName
+                    binding.lAddressResult.tvAddressType.text = "도로명"
+                }
+            }
+
         }
+
+        // 빌딩 이름이 존재 하면 빌딩이름으로 보여주기
+        private fun isExistBuildingName(item: AddressSearchResultDocumentResponse) {
+            if (item.roadAddress!!.buildingName.isNullOrEmpty()) {
+                binding.lAddressResult.tvSearchKeyword.text = item.addressName
+            } else {
+                binding.lAddressResult.tvSearchKeyword.text = item.roadAddress!!.buildingName
+            }
+        }
+
     }
 }
-

--- a/app/src/main/java/com/giftfunding/osds/ui/address/adapter/AddressSearchAdapter3.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/address/adapter/AddressSearchAdapter3.kt
@@ -1,0 +1,73 @@
+package com.giftfunding.osds.ui.address.adapter
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.giftfunding.osds.data.response.address.AddressSearchResultDocumentResponse
+import com.giftfunding.osds.databinding.ItemAddressSearchBinding
+import com.giftfunding.osds.ui.address.AddressSearchClickListener
+
+//삭제 예정
+class AddressSearchAdapter3 :
+    RecyclerView.Adapter<AddressSearchAdapter3.AddressSearchResultViewHolder>() {
+
+    private var addressItems = ArrayList<AddressSearchResultDocumentResponse>()
+    private lateinit var keyword: String
+    private lateinit var itemClickListener: AddressSearchClickListener
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): AddressSearchResultViewHolder =
+        AddressSearchResultViewHolder(
+            ItemAddressSearchBinding.inflate(
+                LayoutInflater.from(parent.context), parent, false
+            )
+        )
+
+    override fun onBindViewHolder(holder: AddressSearchResultViewHolder, position: Int) {
+        holder.onBind(addressItems[position], keyword)
+        holder.itemView.setOnClickListener{
+            itemClickListener.addressSearchClickable(addressItems[position])
+        }
+    }
+
+    override fun getItemCount(): Int = addressItems.size
+
+    // 인터페이스 주입
+    fun setItemClickListener(addressSearchClickListener: AddressSearchClickListener) {
+        this.itemClickListener = addressSearchClickListener
+    }
+
+    // 키워드 주입
+    fun setKeyword(keyword: String){
+        this.keyword = keyword
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun addItems(address: List<AddressSearchResultDocumentResponse>) {
+        addressItems.addAll(address)
+        notifyDataSetChanged()
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun clearItems() {
+        addressItems.clear()
+        notifyDataSetChanged()
+    }
+
+    class AddressSearchResultViewHolder(
+        private val binding: ItemAddressSearchBinding,
+    ) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun onBind(
+            item: AddressSearchResultDocumentResponse,
+            keyword: String,
+        ) {
+//            binding.lAddressName.tvAddress.setAddressTextColor(item.addressName!!, keyword)
+        }
+    }
+}
+

--- a/app/src/main/java/com/giftfunding/osds/ui/anniversary/AnniversaryDateSelectFragment.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/anniversary/AnniversaryDateSelectFragment.kt
@@ -1,6 +1,5 @@
 package com.giftfunding.osds.ui.anniversary
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.RadioButton
@@ -10,7 +9,6 @@ import com.giftfunding.osds.*
 import com.giftfunding.osds.base.BaseFragment
 import com.giftfunding.osds.databinding.FragmentAnniversarySelectDateBinding
 import com.giftfunding.osds.enum.AnniversaryType
-import com.giftfunding.osds.ui.address.AddressActivity
 import com.giftfunding.osds.ui.anniversary.viewmodel.AnniversaryViewModel
 import com.giftfunding.osds.util.initDay
 import com.giftfunding.osds.util.initMonth

--- a/app/src/main/java/com/giftfunding/osds/ui/anniversary/AnniversarySelectFragment.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/anniversary/AnniversarySelectFragment.kt
@@ -7,7 +7,7 @@ import com.giftfunding.osds.R
 import com.giftfunding.osds.base.BaseFragment
 import com.giftfunding.osds.databinding.FragmentAnniversarySelectBinding
 import com.giftfunding.osds.enum.AnniversaryType
-import com.giftfunding.osds.util.Util
+import com.giftfunding.osds.util.showLongToast
 
 class AnniversarySelectFragment : BaseFragment<FragmentAnniversarySelectBinding>() {
 
@@ -38,7 +38,7 @@ class AnniversarySelectFragment : BaseFragment<FragmentAnniversarySelectBinding>
                     if (validateUserInput()) {
                         changeFragment(AnniversaryType.USER_INPUT)
                     } else {
-                        Util.showLongToast(
+                        showLongToast(
                             requireContext(),
                             getString(R.string.content_empty_user_input_anniversary)
                         )

--- a/app/src/main/java/com/giftfunding/osds/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/giftfunding/osds/ui/main/MainActivity.kt
@@ -1,12 +1,7 @@
 package com.giftfunding.osds.ui.main
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
-import androidx.databinding.DataBindingUtil.setContentView
-import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
-import androidx.navigation.NavDestination
 import androidx.navigation.fragment.FragmentNavigator
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
@@ -50,8 +45,15 @@ class MainActivity : BaseActivity<ActivityMainBinding>(ActivityMainBinding::infl
                     setToolbarType(ToolbarType.NORMAL)
                     setBackButtonVisible(VisibleState.VISIBLE)
                     setBackButton(BackButton.BACK)
-                    setCloseButton(VisibleState.VISIBLE)
+                    setCloseButton(VisibleState.INVISIBLE)
                     setTitle(resources.getString(R.string.title_setting_address))
+                }
+
+                "com.giftfunding.osds.ui.address.AddressSearchFragment" -> {
+                    setToolbarType(ToolbarType.NORMAL)
+                    setBackButtonVisible(VisibleState.INVISIBLE)
+                    setCloseButton(VisibleState.VISIBLE)
+                    setTitle(resources.getString(R.string.title_address_search))
                 }
             }
         }

--- a/app/src/main/java/com/giftfunding/osds/util/Edittext.kt
+++ b/app/src/main/java/com/giftfunding/osds/util/Edittext.kt
@@ -1,0 +1,58 @@
+package com.giftfunding.osds.util
+
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
+import androidx.annotation.DrawableRes
+import androidx.annotation.NonNull
+import androidx.appcompat.content.res.AppCompatResources
+
+fun EditText.textClear(){
+
+}
+
+fun EditText.changeBackgroundColor(
+    @NonNull context: Context,
+    @DrawableRes backgroundResId: Int,
+) {
+    background = AppCompatResources.getDrawable(
+        context,
+        backgroundResId
+    )
+}
+
+fun EditText.hideSearchIcon() {
+    setCompoundDrawablesWithIntrinsicBounds(
+        0,
+        0,
+        0,
+        0
+    )
+}
+
+fun EditText.showSearchIcon(
+    @DrawableRes icon: Int
+) {
+    setCompoundDrawablesWithIntrinsicBounds(
+        icon,
+        0,
+        0,
+        0
+    )
+}
+
+fun EditText.setFocusAndShowKeyboard(context: Context) {
+    this.requestFocus()
+    val inputMethodManager =
+        context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    inputMethodManager.showSoftInput(this, 0)
+}
+
+fun EditText.clearFocusAndHideKeyboard(context: Context) {
+    this.clearFocus()
+    this.postDelayed({
+        val inputMethodManager =
+            context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(this.windowToken, 0)
+    }, 30)
+}

--- a/app/src/main/java/com/giftfunding/osds/util/Util.kt
+++ b/app/src/main/java/com/giftfunding/osds/util/Util.kt
@@ -1,11 +1,17 @@
 package com.giftfunding.osds.util
 
 import android.content.Context
+import android.view.View
 import android.widget.Toast
+import com.google.android.material.snackbar.Snackbar
 
 object Util {
     fun showLongToast(context: Context, message : String){
         Toast.makeText(context, message, Toast.LENGTH_LONG).show()
     }
 
+    fun showSnackBar(view: View, message: String ){
+        val snackBar = Snackbar.make(view, message, Snackbar.LENGTH_LONG)
+        snackBar.show()
+    }
 }

--- a/app/src/main/java/com/giftfunding/osds/util/Util.kt
+++ b/app/src/main/java/com/giftfunding/osds/util/Util.kt
@@ -5,13 +5,11 @@ import android.view.View
 import android.widget.Toast
 import com.google.android.material.snackbar.Snackbar
 
-object Util {
-    fun showLongToast(context: Context, message : String){
-        Toast.makeText(context, message, Toast.LENGTH_LONG).show()
-    }
+fun showLongToast(context: Context, message: String) {
+    Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+}
 
-    fun showSnackBar(view: View, message: String ){
-        val snackBar = Snackbar.make(view, message, Snackbar.LENGTH_LONG)
-        snackBar.show()
-    }
+fun showSnackBar(view: View, message: String) {
+    val snackBar = Snackbar.make(view, message, Snackbar.LENGTH_LONG)
+    snackBar.show()
 }

--- a/app/src/main/res/layout/activity_address_search.xml
+++ b/app/src/main/res/layout/activity_address_search.xml
@@ -35,7 +35,7 @@
         android:layout_width="0dp"
         android:layout_height="46dp"
         android:layout_marginHorizontal="28dp"
-        android:layout_marginTop="12dp"
+        android:layout_marginTop="8dp"
         android:background="@drawable/bg_rect_midnight_express_solitude2_radius16_stroke2"
         android:drawableStart="@drawable/ic_search"
         android:drawablePadding="8dp"
@@ -47,6 +47,7 @@
         android:paddingEnd="50dp"
         android:textColorHint="@color/link_water"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tb_address_search" />
 

--- a/app/src/main/res/layout/content_address_search_guide.xml
+++ b/app/src/main/res/layout/content_address_search_guide.xml
@@ -79,34 +79,34 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_land_lot_number" />
 
-    <ImageView
-        android:id="@+id/iv_building_name_bullet_point"
-        android:layout_width="4dp"
-        android:layout_height="4dp"
-        android:src="@drawable/ic_bullet_point"
-        app:layout_constraintBottom_toBottomOf="@id/tv_building_name"
-        app:layout_constraintStart_toStartOf="@id/iv_land_lot_number_bullet_point"
-        app:layout_constraintTop_toTopOf="@id/tv_building_name" />
+    <!--    <ImageView-->
+    <!--        android:id="@+id/iv_building_name_bullet_point"-->
+    <!--        android:layout_width="4dp"-->
+    <!--        android:layout_height="4dp"-->
+    <!--        android:src="@drawable/ic_bullet_point"-->
+    <!--        app:layout_constraintBottom_toBottomOf="@id/tv_building_name"-->
+    <!--        app:layout_constraintStart_toStartOf="@id/iv_land_lot_number_bullet_point"-->
+    <!--        app:layout_constraintTop_toTopOf="@id/tv_building_name" />-->
 
-    <TextView
-        android:id="@+id/tv_building_name"
-        style="@style/noto_sans_kr_medium_14_raven_padding0"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="18dp"
-        android:text="@string/content_building_name"
-        app:layout_constraintStart_toStartOf="@id/tv_road_name"
-        app:layout_constraintTop_toBottomOf="@id/tv_land_lot_number_example" />
+    <!--    <TextView-->
+    <!--        android:id="@+id/tv_building_name"-->
+    <!--        style="@style/noto_sans_kr_medium_14_raven_padding0"-->
+    <!--        android:layout_width="wrap_content"-->
+    <!--        android:layout_height="wrap_content"-->
+    <!--        android:layout_marginTop="18dp"-->
+    <!--        android:text="@string/content_building_name"-->
+    <!--        app:layout_constraintStart_toStartOf="@id/tv_road_name"-->
+    <!--        app:layout_constraintTop_toBottomOf="@id/tv_land_lot_number_example" />-->
 
-    <TextView
-        android:id="@+id/tv_building_name_example"
-        style="@style/noto_sans_kr_medium_13_link_water_padding0"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="38dp"
-        android:layout_marginTop="1dp"
-        android:text="@string/content_building_name_example"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_building_name" />
+    <!--    <TextView-->
+    <!--        android:id="@+id/tv_building_name_example"-->
+    <!--        style="@style/noto_sans_kr_medium_13_link_water_padding0"-->
+    <!--        android:layout_width="wrap_content"-->
+    <!--        android:layout_height="wrap_content"-->
+    <!--        android:layout_marginStart="38dp"-->
+    <!--        android:layout_marginTop="1dp"-->
+    <!--        android:text="@string/content_building_name_example"-->
+    <!--        app:layout_constraintStart_toStartOf="parent"-->
+    <!--        app:layout_constraintTop_toBottomOf="@id/tv_building_name" />-->
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/content_address_search_result.xml
+++ b/app/src/main/res/layout/content_address_search_result.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">

--- a/app/src/main/res/layout/fragment_address_search.xml
+++ b/app/src/main/res/layout/fragment_address_search.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <EditText
+            android:id="@+id/edit_address_search"
+            style="@style/noto_sans_kr_medium_16_midnight_express_padding0"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="28dp"
+            android:layout_marginTop="20dp"
+            android:background="@drawable/bg_rect_midnight_express_solitude2_radius16_stroke2"
+            android:drawableStart="@drawable/ic_search"
+            android:drawablePadding="8dp"
+            android:hint="@string/content_input"
+            android:imeOptions="actionSearch"
+            android:inputType="text"
+            android:maxLines="1"
+            android:paddingVertical="14dp"
+            android:paddingStart="18dp"
+            android:paddingEnd="50dp"
+            android:textColorHint="@color/link_water"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageButton
+            android:id="@+id/btn_text_delete"
+            android:layout_width="50dp"
+            android:layout_height="46dp"
+            android:background="@color/transparent"
+            android:src="@drawable/ic_delete"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@+id/edit_address_search"
+            app:layout_constraintEnd_toEndOf="@id/edit_address_search"
+            app:layout_constraintTop_toTopOf="@id/edit_address_search"
+            tools:visibility="visible" />
+
+        <View
+            android:id="@+id/div_address_search"
+            android:layout_width="match_parent"
+            android:layout_height="2dp"
+            android:layout_marginTop="20dp"
+            android:background="@color/hawkes_blue"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/edit_address_search" />
+
+        <include
+            android:id="@+id/view_address_search_guide"
+            layout="@layout/content_address_search_guide"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/div_address_search"
+            tools:visibility="gone" />
+
+        <include
+            android:id="@+id/view_address_search_result"
+            layout="@layout/content_address_search_result"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/div_address_search"
+            tools:visibility="visible" />
+
+        <include
+            android:id="@+id/view_address_search_no_result"
+            layout="@layout/content_address_search_no_result"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/div_address_search"
+            tools:visibility="gone" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_address_search.xml
+++ b/app/src/main/res/layout/item_address_search.xml
@@ -1,20 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <include
-        android:id="@+id/l_address_name"
-        layout="@layout/item_content_address_name"
+        android:id="@+id/l_address_result"
+        layout="@layout/item_address_search_result"
         android:visibility="visible">
     </include>
-
-<!--    <include-->
-<!--        android:id="@+id/l_address_result"-->
-<!--        layout="@layout/item_address_search_result"-->
-<!--        android:visibility="gone">-->
-<!--    </include>-->
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_address_search_result.xml
+++ b/app/src/main/res/layout/item_address_search_result.xml
@@ -2,7 +2,8 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <TextView
         android:id="@+id/tv_search_keyword"
@@ -11,10 +12,10 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="27dp"
         android:layout_marginTop="20dp"
-        android:text="검색어 영역입니다."
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="packed" />
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="검색어 영역입니다."/>
 
     <TextView
         android:id="@+id/tv_address_type"

--- a/app/src/main/res/navigation/navigation_main.xml
+++ b/app/src/main/res/navigation/navigation_main.xml
@@ -14,6 +14,7 @@
             android:id="@+id/action_anniversarySelectFragment_to_anniversaryDateSelectFragment"
             app:destination="@id/anniversaryDateSelectFragment" />
     </fragment>
+
     <fragment
         android:id="@+id/anniversaryDateSelectFragment"
         android:name="com.giftfunding.osds.ui.anniversary.AnniversaryDateSelectFragment"
@@ -31,11 +32,21 @@
             android:id="@+id/action_anniversaryDateSelectFragment_to_addressFragment"
             app:destination="@id/addressFragment" />
     </fragment>
+
     <fragment
         android:id="@+id/addressFragment"
         android:name="com.giftfunding.osds.ui.address.AddressFragment"
-        android:label="addressFragment"
+        android:label="AddressFragment"
         tools:layout="@layout/fragment_address">
 
+        <action
+            android:id="@+id/action_addressFragment_to_addressSearchFragment"
+            app:destination="@id/addressSearchFragment" />
     </fragment>
+
+    <fragment
+        android:id="@+id/addressSearchFragment"
+        android:name="com.giftfunding.osds.ui.address.AddressSearchFragment"
+        android:label="AddressSearchFragment"
+        tools:layout="@layout/fragment_address_search"/>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,21 +85,22 @@
     <string name="content_empty_user_input_anniversary">기념일을 입력해주세요.</string>
 
     <!-- 배송지 입력화면 -->
-    <string name="content_address">펀딩 완료된 선물을\n어디로 배송해 드릴까요?</string>
-    <string name="content_input">지번, 도로명, 건물명으로 검색</string>
     <string name="title_complete">완료</string>
     <string name="title_register_complete">등록 완료</string>
     <string name="title_search_guide">이렇게 검색해 보세요.</string>
     <string name="title_address_detail">주소 상세입력</string>
     <string name="title_address_search">주소 검색</string>
+    <string name="content_address">펀딩 완료된 선물을\n어디로 배송해 드릴까요?</string>
+    <string name="content_input">지번, 도로명, 건물명으로 검색</string>
     <string name="content_road_name">도로명 + 건물번호</string>
     <string name="content_road_name_example">예) 강남대로 94길</string>
     <string name="content_land_lot_number">지역명 + 번지</string>
-    <string name="content_land_lot_number_example">예) 역상동 111&#8211;1</string>
+    <string name="content_land_lot_number_example">예) 역삼동 111&#8211;1</string>
     <string name="content_building_name">건물명, 아파트명</string>
     <string name="content_building_name_example">예) 동신아파트</string>
     <string name="content_address_detail_hint">상세 주소를 입력해주세요. 예) A동 101호</string>
-    <string name="content_no_address_result">검색 결과가 없습니다.\n도로명, 지번, 건물명, 아파트 명으로\n재 검색해주세요.</string>
+    <string name="content_no_address_result">검색 결과가 없습니다.\n도로명, 지번, 건물명으로\n재 검색해주세요.</string>
+    <string name="content_empty_address">주소지를 입력해주세요.</string>
 
     <!-- 선물담기 -->
     <string name="content_put_gift">선물 담기</string>


### PR DESCRIPTION
주소검색 페이지 프래그먼트로 변경 작업

-- 중점적으로 볼꺼
* MainActivity
* AddressSearchFragment
* AddressSearchViewModel
*  R.layout.fragment_address_search
* editText.kt
* AddressSearchAdapter
* String -> 아파트명으로는 검색 불가능이라 관련된건 xml에서 삭제 또는 주석처리함
* Util

-- 기능 추가된거
AddressSearchFragment 진입시 editText 자동 포커스 및 키보드 올라오기
스낵바 추가
edittext 백그라운드 변경 - 색 / 검색 아이콘 / delete 버튼
delete버튼 클릭시 edittext 초기화 + 기존뷰 유지
검색완료시 키보드 하단으로 내리기
주소검색 관련 페이징 작업 추가